### PR TITLE
Made R&D page responsive & mobile friendly

### DIFF
--- a/src/components/rnd/Description.tsx
+++ b/src/components/rnd/Description.tsx
@@ -1,7 +1,7 @@
 const Description = () => {
   return (
     <>
-      <p className="mx-auto my-7 w-2/3 text-center text-lg md:w-1/2 md:text-xl">
+      <p className="mx-auto my-7 w-2/3 text-center text-base md:w-1/2 md:text-xl">
         We write and publish articles related to AI research on medium’s
         HumansForAI page with over 1K+ subscribers. Our team writes weekly
         newsletters with current job postings, AI industry updates and more!

--- a/src/components/rnd/Description.tsx
+++ b/src/components/rnd/Description.tsx
@@ -1,7 +1,7 @@
 const Description = () => {
   return (
     <>
-      <p className="mx-auto my-7 w-1/2 text-center text-xl">
+      <p className="mx-auto my-7 w-2/3 text-center text-lg md:w-1/2 md:text-xl">
         We write and publish articles related to AI research on medium’s
         HumansForAI page with over 1K+ subscribers. Our team writes weekly
         newsletters with current job postings, AI industry updates and more!

--- a/src/components/rnd/RDArticles.tsx
+++ b/src/components/rnd/RDArticles.tsx
@@ -4,11 +4,11 @@ import Image from "next/image";
 const RDArticles = () => {
   return (
     <>
-      <div className="grid h-[75vh] grid-cols-3 grid-rows-2 gap-10 px-40 py-10">
+      <div className="grid grid-cols-1 gap-10 px-12 py-5 md:h-[75vh] md:grid-cols-3 md:grid-rows-2 md:px-40 md:py-10">
         {RDArticlesData.map(({ Link, Picture, Alt }, index) => (
           <a key={index} href={Link}>
             <Image
-              className="bg-aisc-gray/10 h-full w-full rounded-4xl object-cover"
+              className="bg-aisc-gray/10 h-[25vh] w-full rounded-4xl object-cover md:h-full"
               src={Picture}
               alt={Alt}
               width={500}

--- a/src/components/rnd/RDArticles.tsx
+++ b/src/components/rnd/RDArticles.tsx
@@ -3,21 +3,22 @@ import Image from "next/image";
 
 const RDArticles = () => {
   return (
-    <>
-      <div className="grid grid-cols-1 gap-10 px-12 py-5 sm:px-40 md:grid-cols-3 md:grid-rows-2 md:px-20 md:py-10 lg:px-40">
-        {RDArticlesData.map(({ Link, Picture, Alt }, index) => (
-          <a key={index} href={Link}>
-            <Image
-              className="bg-aisc-gray/10 h-[25vh] w-full rounded-4xl object-cover"
-              src={Picture}
-              alt={Alt}
-              width={500}
-              height={500}
-            />
-          </a>
-        ))}
-      </div>
-    </>
+    <div className="grid grid-cols-1 py-8 gap-10 px-8 md:grid-cols-3 md:grid-rows-2 md:px-20 lg:px-40">
+      {RDArticlesData.map(({ Link, Picture, Alt }, index) => (
+        <a
+          key={index}
+          href={Link}
+          target="_blank"
+          className="flex flex-col"
+        >
+          <Image
+            className="bg-aisc-gray/10 h-[25vh] w-2/3 md:w-full mx-auto rounded-4xl object-cover"
+            src={Picture}
+            alt={Alt}
+          />
+        </a>
+      ))}
+    </div>
   );
 };
 

--- a/src/components/rnd/RDArticles.tsx
+++ b/src/components/rnd/RDArticles.tsx
@@ -3,16 +3,11 @@ import Image from "next/image";
 
 const RDArticles = () => {
   return (
-    <div className="grid grid-cols-1 py-8 gap-10 px-8 md:grid-cols-3 md:grid-rows-2 md:px-20 lg:px-40">
+    <div className="grid grid-cols-1 gap-10 px-8 py-8 md:grid-cols-3 md:grid-rows-2 md:px-20 lg:px-40">
       {RDArticlesData.map(({ Link, Picture, Alt }, index) => (
-        <a
-          key={index}
-          href={Link}
-          target="_blank"
-          className="flex flex-col"
-        >
+        <a key={index} href={Link} target="_blank" className="flex flex-col">
           <Image
-            className="bg-aisc-gray/10 h-[25vh] w-2/3 md:w-full mx-auto rounded-4xl object-cover"
+            className="bg-aisc-gray/10 mx-auto h-[25vh] w-2/3 rounded-4xl object-cover md:w-full"
             src={Picture}
             alt={Alt}
           />

--- a/src/components/rnd/RDArticles.tsx
+++ b/src/components/rnd/RDArticles.tsx
@@ -4,11 +4,11 @@ import Image from "next/image";
 const RDArticles = () => {
   return (
     <>
-      <div className="grid grid-cols-1 gap-10 px-12 py-5 md:h-[75vh] md:grid-cols-3 md:grid-rows-2 md:px-40 md:py-10">
+      <div className="grid grid-cols-1 gap-10 px-12 py-5 sm:px-40 md:grid-cols-3 md:grid-rows-2 md:px-20 md:py-10 lg:px-40">
         {RDArticlesData.map(({ Link, Picture, Alt }, index) => (
           <a key={index} href={Link}>
             <Image
-              className="bg-aisc-gray/10 h-[25vh] w-full rounded-4xl object-cover md:h-full"
+              className="bg-aisc-gray/10 h-[25vh] w-full rounded-4xl object-cover"
               src={Picture}
               alt={Alt}
               width={500}

--- a/src/data/RDArticlesData.tsx
+++ b/src/data/RDArticlesData.tsx
@@ -1,27 +1,34 @@
+import ambiguous from "@/public/placeholders/ambiguous.webp";
+import internEvent from "@/public/placeholders/intern_event.webp";
+import womenInTech from "@/public/placeholders/women_in_tech_event.webp";
+import workshop from "@/public/placeholders/workshop.webp";
+
+import { StaticImageData } from "next/image";
+
 export interface RDArticlesData {
-  Picture: string;
+  Picture: StaticImageData;
   Link: string;
   Alt: string;
 }
 
 export const RDArticlesData: RDArticlesData[] = [
   {
-    Picture: "/placeholders/ambiguous.webp",
+    Picture: ambiguous,
     Link: "https://medium.com/@humansforai/ai-ml-in-autonomous-driving-3fbb992dcfc4",
     Alt: "AI & ML in Autonomous Driving",
   },
   {
-    Picture: "/placeholders/intern_event.webp",
+    Picture: internEvent,
     Link: "https://medium.com/@humansforai/natural-language-processing-simplified-49a7fe6c4dff",
     Alt: "Natural Language Processing Simplified",
   },
   {
-    Picture: "/placeholders/women_in_tech_event.webp",
+    Picture: womenInTech,
     Link: "https://medium.com/@humansforai/hidden-dangers-of-ai-deepfake-technology-a0a940951dc2",
     Alt: "Hidden Dangers of AI: Deepfake Technology",
   },
   {
-    Picture: "/placeholders/workshop.webp",
+    Picture: workshop,
     Link: "https://medium.com/@humansforai/ai-can-learn-from-their-dreams-world-models-3018fb21602b",
     Alt: "AI Can Learn From Their Dreams: World Models",
   },


### PR DESCRIPTION
I decreased text size, adjusted padding, and changed the grid to a single column for mobile screens. I did not change anything for medium screens and above view (above md). 
View on a phone:
<img width="668" height="2278" alt="screencapture-localhost-3000-rnd-2025-07-18-22_08_11" src="https://github.com/user-attachments/assets/bccdc148-cc4f-438e-afe0-96e6fac18081" />
View on my laptop:
<img width="2476" height="1949" alt="screencapture-localhost-3000-rnd-2025-07-18-21_39_08" src="https://github.com/user-attachments/assets/67645406-353d-4e11-89d2-9663b2fa2af0" />
