### PR TITLE
Cade jordan/mobile projects page

### DIFF
--- a/src/components/projects/LeftAlignedProject.tsx
+++ b/src/components/projects/LeftAlignedProject.tsx
@@ -10,10 +10,10 @@ interface ProjectsProps {
 
 const LeftAlignedProject = ({ image, title, description }: ProjectsProps) => {
   return (
-    <div className="to-aisc-blue/50 flex flex-col items-center bg-gradient-to-r from-white from-5% to-95% p-3 sm:flex-row">
-      <div className="flex w-2/3 flex-col gap-2 p-5">
-        <p className="text-2xl font-bold">{title}</p>
-        <p className="text-xl">{description}</p>
+    <div className="to-aisc-blue/50 flex flex-col items-center bg-gradient-to-r from-white from-5% to-95% p-0 p-3 sm:flex-row">
+      <div className="flex w-2/3 flex-col gap-2 py-5 md:p-5">
+        <p className="text-lg font-bold md:text-2xl">{title}</p>
+        <p className="text-sm md:text-xl">{description}</p>
       </div>
       <Image
         className="mx-auto h-[20vh] w-[25vw] rounded-2xl object-cover"

--- a/src/components/projects/LeftAlignedProject.tsx
+++ b/src/components/projects/LeftAlignedProject.tsx
@@ -10,7 +10,7 @@ interface ProjectsProps {
 
 const LeftAlignedProject = ({ image, title, description }: ProjectsProps) => {
   return (
-    <div className="to-aisc-blue/50 flex flex-col items-center bg-gradient-to-r from-white from-5% to-95% p-3 md:flex-row">
+    <div className="to-aisc-blue/50 flex flex-col items-center bg-gradient-to-r from-white from-5% to-95% p-3 sm:flex-row">
       <div className="flex w-2/3 flex-col gap-2 p-5">
         <p className="text-2xl font-bold">{title}</p>
         <p className="text-xl">{description}</p>

--- a/src/components/projects/LeftAlignedProject.tsx
+++ b/src/components/projects/LeftAlignedProject.tsx
@@ -10,7 +10,7 @@ interface ProjectsProps {
 
 const LeftAlignedProject = ({ image, title, description }: ProjectsProps) => {
   return (
-    <div className="to-aisc-blue/50 flex flex-row items-start bg-gradient-to-r from-white from-5% to-95% p-3">
+    <div className="to-aisc-blue/50 flex flex-col items-center bg-gradient-to-r from-white from-5% to-95% p-3 md:flex-row">
       <div className="flex w-2/3 flex-col gap-2 p-5">
         <p className="text-2xl font-bold">{title}</p>
         <p className="text-xl">{description}</p>

--- a/src/components/projects/LeftAlignedProject.tsx
+++ b/src/components/projects/LeftAlignedProject.tsx
@@ -10,7 +10,7 @@ interface ProjectsProps {
 
 const LeftAlignedProject = ({ image, title, description }: ProjectsProps) => {
   return (
-    <div className="to-aisc-blue/50 flex flex-col items-center bg-gradient-to-r from-white from-5% to-95% p-0 p-3 sm:flex-row">
+    <div className="to-aisc-blue/50 flex flex-col items-center bg-gradient-to-r from-white from-5% to-95% p-3 sm:flex-row">
       <div className="flex w-2/3 flex-col gap-2 py-5 md:p-5">
         <p className="text-lg font-bold md:text-2xl">{title}</p>
         <p className="text-sm md:text-xl">{description}</p>

--- a/src/components/projects/RightAlignedProject.tsx
+++ b/src/components/projects/RightAlignedProject.tsx
@@ -16,9 +16,9 @@ const RightAlignedProject = ({ image, title, description }: ProjectsProps) => {
         src={image}
         alt={title}
       />
-      <div className="w-2/3 flex-row gap-2 p-5 text-left sm:text-right">
-        <p className="text-2xl font-bold">{title}</p>
-        <p className="text-xl">{description}</p>
+      <div className="w-2/3 flex-row gap-2 text-left sm:text-right md:p-5">
+        <p className="text-lg font-bold md:text-2xl">{title}</p>
+        <p className="text-sm md:text-xl">{description}</p>
       </div>
     </div>
   );

--- a/src/components/projects/RightAlignedProject.tsx
+++ b/src/components/projects/RightAlignedProject.tsx
@@ -10,13 +10,13 @@ interface ProjectsProps {
 
 const RightAlignedProject = ({ image, title, description }: ProjectsProps) => {
   return (
-    <div className="flex items-center bg-white p-3">
+    <div className="flex flex-col-reverse items-center bg-white p-3 md:flex-row">
       <Image
         className="mx-auto h-[20vh] w-[25vw] rounded-2xl object-cover"
         src={image}
         alt={title}
       />
-      <div className="flex w-2/3 flex-col gap-2 p-5 text-right">
+      <div className="flex w-2/3 gap-2 p-5 text-right">
         <p className="text-2xl font-bold">{title}</p>
         <p className="text-xl">{description}</p>
       </div>

--- a/src/components/projects/RightAlignedProject.tsx
+++ b/src/components/projects/RightAlignedProject.tsx
@@ -10,18 +10,17 @@ interface ProjectsProps {
 
 const RightAlignedProject = ({ image, title, description }: ProjectsProps) => {
   return (
-    <div className="flex flex-col-reverse items-center bg-white p-3 md:flex-row">
+    <div className="flex flex-col-reverse items-center bg-white p-3 sm:flex-row">
       <Image
         className="mx-auto h-[20vh] w-[25vw] rounded-2xl object-cover"
         src={image}
         alt={title}
       />
-      <div className="flex w-2/3 gap-2 p-5 text-right">
+      <div className="w-2/3 flex-row gap-2 p-5 text-left sm:text-right">
         <p className="text-2xl font-bold">{title}</p>
         <p className="text-xl">{description}</p>
       </div>
     </div>
   );
 };
-
 export default RightAlignedProject;


### PR DESCRIPTION
The layout doesn't match the Figma. I moved the image below each project section because when it was side by side with the text, both the image and text looked too small. Let me know if you want me to revert it to the Figma design. 

<img width="447" height="797" alt="image" src="https://github.com/user-attachments/assets/953a1e0e-f9f3-43a5-9e25-b6daa98e4e2c" />

<img width="450" height="805" alt="image" src="https://github.com/user-attachments/assets/8349db3b-19dd-487a-99de-8767d3ea9384" />
