### PR TITLE
animated stats bar and added countUp package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "motion": "^12.23.5",
         "next": "15.2.4",
         "react": "19.0.0",
+        "react-countup": "^6.5.3",
         "react-dom": "19.0.0",
         "react-icons": "^5.5.0",
         "tailwind-merge": "^3.3.1"
@@ -1881,6 +1882,12 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/countup.js": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
+      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -4603,6 +4610,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-countup": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.5.3.tgz",
+      "integrity": "sha512-udnqVQitxC7QWADSPDOxVWULkLvKUWrDapn5i53HE4DPRVgs+Y5rr4bo25qEl8jSh+0l2cToJgGMx+clxPM3+w==",
+      "license": "MIT",
+      "dependencies": {
+        "countup.js": "^2.8.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "motion": "^12.23.5",
     "next": "15.2.4",
     "react": "19.0.0",
+    "react-countup": "^6.5.3",
     "react-dom": "19.0.0",
     "react-icons": "^5.5.0",
     "tailwind-merge": "^3.3.1"

--- a/src/components/home/StatisticsBar.tsx
+++ b/src/components/home/StatisticsBar.tsx
@@ -1,19 +1,26 @@
+"use client";
+import CountUp from "react-countup";
+
 const Stats = [
   {
     Stat: "Officers",
-    Quantity: "10",
+    Quantity: 10,
+    Suffix: "",
   },
   {
     Stat: "Members",
-    Quantity: "100+",
+    Quantity: 100,
+    Suffix: "+",
   },
   {
     Stat: "Workshops",
-    Quantity: "5",
+    Quantity: 5,
+    Suffix: "",
   },
   {
     Stat: "Alumni",
-    Quantity: "20+",
+    Quantity: 20,
+    Suffix: "+",
   },
 ];
 
@@ -22,10 +29,19 @@ const StatisticsBar = () => {
     <div className="bg-aisc-gray flex w-full flex-col items-center justify-center">
       <div className="from-aisc-pink to-aisc-blue h-[4px] w-full bg-linear-to-r/shorter" />
       <div className="my-16 flex w-full flex-col items-center justify-evenly px-4 text-center text-white sm:flex-row sm:justify-evenly">
-        {Stats.map(({ Stat, Quantity }, idx) => (
+        {Stats.map(({ Stat, Quantity, Suffix }, idx) => (
           <div key={idx} className="flex flex-col items-center">
             <span className="mb-6 text-5xl font-bold sm:text-6xl md:text-7xl">
-              {Quantity}
+              <CountUp
+                start={0}
+                end={Quantity}
+                duration={2}
+                enableScrollSpy={true}
+                scrollSpyOnce={true}
+                suffix={Suffix}
+              >
+                {({ countUpRef }) => <span ref={countUpRef} />}
+              </CountUp>
             </span>
             <span className="text-base sm:text-lg md:text-xl">{Stat}</span>
           </div>


### PR DESCRIPTION
In order to add the counting up animation, I had to add a new package countUp (same one that ACM website uses). Motion has a counting feature but it requires motion+ (paid). 

https://github.com/user-attachments/assets/dce2f6fe-0385-496d-bd27-e7d16866c845

